### PR TITLE
Add desktop environments

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,6 +41,11 @@
           <a href="https://github.com/WayfireWM/wayfire">Wayfire</a>
         </li>
         <li>
+          Desktop environment:
+          <a href="https://www.gnome.org/">GNOME</a>,
+          <a href="https://kde.org/">KDE</a>
+        </li>
+        <li>
           Document viewer:
           <a href="https://git.pwmt.org/pwmt/zathura">Zathura</a>
         </li>


### PR DESCRIPTION
In practice only GNOME and KDE offer reasonable Wayland support "out of the box" as a complete desktop environment nowadays. It's worth a mention.