### PR TITLE
fix: correct information for KDE Wayland on NVIDIA hardware

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -157,8 +157,8 @@
         <a href="https://wiki.gnome.org/Initiatives/Wayland/NVIDIA">GNOME</a>
       </li>
       <li class="list__item--kinda">
-        With "showstoppers" it runs, on
-        <a href="https://community.kde.org/Plasma/Wayland_Showstoppers">KDE</a>
+        With limitations/caveats it runs, on
+        <a href="https://community.kde.org/Plasma/Wayland/Nvidia">KDE</a>
       </li>
       <li class="list__item--ko">
         For all others scenarios, it does <b>NOT</b> work 😔


### PR DESCRIPTION
Fixes #56 