### PR TITLE
fix: correct KDE/Plasma name

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
       <li class="list__item--ok">
         Desktop environment:
         <a href="https://www.gnome.org/">GNOME</a>,
-        <a href="https://kde.org/">KDE</a>
+        <a href="https://kde.org/plasma-desktop">Plasma</a>
       </li>
       <li class="list__item--ok">
         Document viewer:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,7 +33,7 @@
       <li class="list__item--ok">
         Desktop environment:
         <a href="https://www.gnome.org/">GNOME</a>,
-        <a href="https://kde.org/plasma-desktop">Plasma</a>
+        <a href="https://kde.org/plasma-desktop">KDE Plasma</a>
       </li>
       <li class="list__item--ok">
         Document viewer:


### PR DESCRIPTION
KDE (the desktop environement) was last released with KDE3. It's now called Plasma Desktop or simply Plasma.