### PR TITLE
fix: update gmenu repository URL

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -12,7 +12,7 @@
         Application launcher:
         <a href="https://github.com/Cloudef/bemenu">bemenu</a>,
         <a href="https://codeberg.org/dnkl/fuzzel">fuzzel</a>,
-        <a href="https://gitlab.com/tslocum/gmenu">gmenu</a>,
+        <a href="https://code.rocketnine.space/tslocum/gmenu">gmenu</a>,
         <a href="https://sr.ht/~leon_plickat/LavaLauncher/">LavaLauncher</a>,
         <a href="https://ulauncher.io/">Ulauncher</a>,
         <a href="https://hg.sr.ht/~scoopta/wofi">wofi</a>,


### PR DESCRIPTION
gmenu has migrated to a new git hosting site.