### PR TITLE
chore: fix naming, casing, sorting and URLs

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,25 +11,24 @@
       <li class="list__item--ok">
         Application launcher:
         <a href="https://github.com/Cloudef/bemenu">bemenu</a>,
-        <a href="https://codeberg.org/dnkl/fuzzel">fuzzel</a>,
+        <a href="https://codeberg.org/dnkl/fuzzel">Fuzzel</a>,
         <a href="https://code.rocketnine.space/tslocum/gmenu">gmenu</a>,
         <a href="https://github.com/nwg-piotr/nwg-launchers">nwg-launchers</a>,
-        <a href="https://github.com/oknozor/onagre">onagre</a>,
-        <a href="https://github.com/lbonn/rofi">rofi-lbonn</a>,
-        <a href="https://ulauncher.io/">Ulauncher</a>,
-        <a href="https://hg.sr.ht/~scoopta/wofi">wofi</a>,
+        <a href="https://github.com/oknozor/onagre">Onagre</a>,
+        <a href="https://github.com/lbonn/rofi">Rofi (lbonn's fork)</a>,
+        <a href="https://ulauncher.io">Ulauncher</a>,
+        <a href="https://hg.sr.ht/~scoopta/wofi">Wofi</a>,
         <a href="https://github.com/l4l/yofi">yofi</a>
       </li>
       <li class="list__item--ok">
         Clipboard manager:
-        <a href="https://github.com/yory8/clipman">clipman</a>,
-        <a href="https://github.com/bugaevc/wl-clipboard">wl-clipboard</a>,
-        <a href="https://github.com/YaLTeR/wl-clipboard-rs">wl-clipboard-rs</a>
+        <a href="https://github.com/yory8/clipman">Clipman</a>,
+        <a href="https://github.com/bugaevc/wl-clipboard">wl-clipboard</a>
       </li>
       <li class="list__item--ok">
         Color picker:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
-        <a href="https://unix.stackexchange.com/a/523805">grim</a>
+        <a href="https://github.com/emersion/grim">grim</a>
       </li>
       <li class="list__item--ok">
         Compiz support:
@@ -48,89 +47,89 @@
       <li class="list__item--ok">
         Document viewer:
         <a href="https://github.com/mate-desktop/atril">Atril</a>,
-        <a href="https://gitlab.gnome.org/GNOME/evince">Evince</a>,
-        <a href="https://git.pwmt.org/pwmt/zathura">Zathura</a>
+        <a href="https://wiki.gnome.org/Apps/Evince">Evince</a>,
+        <a href="https://git.pwmt.org/pwmt/zathura">zathura</a>
       </li>
       <li class="list__item--ok">
         File manager:
         <a href="https://github.com/KDE/dolphin">Dolphin</a>,
-        <a href="https://gitlab.gnome.org/GNOME/nautilus">Nautilus</a>,
-        <a href="https://github.com/linuxmint/nemo">nemo</a>
+        <a href="https://wiki.gnome.org/Apps/Files">GNOME Files (nautilus)</a>,
+        <a href="https://github.com/linuxmint/nemo">Nemo</a>
       </li>
       <li class="list__item--ok">
         Gamma & day/night adjustment tool:
-        <a href="https://gitlab.com/chinstrap/gammastep">gammastep</a>,
+        <a href="https://gitlab.com/chinstrap/gammastep">Gammastep</a>,
         <a href="https://sr.ht/~kennylevinsen/wlsunset/">wlsunset</a>
       </li>
       <li class="list__item--ok">
         Image viewer:
-        <a href="https://gitlab.gnome.org/GNOME/eog">Eye of GNOME</a>,
+        <a href="https://wiki.gnome.org/Apps/EyeOfGnome">GNOME Image Viewer (eog)</a>,
         <a href="https://github.com/eXeC64/imv">imv</a>
       </li>
       <li class="list__item--ok">
         Login manager:
-        <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>,
-        <a href="https://wiki.gnome.org/Projects/GDM">GDM</a>,
-        <a href="https://sr.ht/~kennylevinsen/greetd/">Greetd</a>
+        <a href="https://wiki.gnome.org/Projects/GDM">GNOME Display Manager (gdm)</a>,
+        <a href="https://sr.ht/~kennylevinsen/greetd/">greetd</a>,
+        <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>
+      </li>
+      <li class="list__item--ok">
+        Network transparency:
+        <a href="https://gitlab.freedesktop.org/mstoeckl/waypipe">Waypipe</a>
+      </li>
+      <li class="list__item--ok">
+        Notification daemon:
+        <a href="https://dunst-project.org">Dunst</a>,
+        <a href="https://codeberg.org/dnkl/fnott">Fnott</a>,
+        <a href="https://github.com/emersion/mako">mako</a>
+      </li>
+      <li class="list__item--ok">
+        Output/display configuration tool:
+        <a href="https://github.com/emersion/kanshi">kanshi</a>,
+        <a href="https://github.com/luispabon/wdisplays">wdisplays</a>,
+        <a href="https://github.com/emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">
         Power menu:
         <a href="https://github.com/ArtsyMacaw/wlogout">wlogout</a>
       </li>
       <li class="list__item--ok">
-        Network transparency:
-        <a href="https://gitlab.freedesktop.org/mstoeckl/waypipe">waypipe</a>
-      </li>
-      <li class="list__item--ok">
-        Notification daemon:
-        <a href="https://github.com/dunst-project/dunst">dunst</a>,
-        <a href="https://codeberg.org/dnkl/fnott">fnott</a>,
-        <a href="https://github.com/emersion/mako">mako</a>
-      </li>
-      <li class="list__item--ok">
-        Output/display configuration tool:
-        <a href="https://github.com/emersion/kanshi">kanshi</a>,
-        <a href="https://github.com/cyclopsian/wdisplays">wdisplays</a>,
-        <a href="https://github.com/emersion/wlr-randr">wlr-randr</a>
-      </li>
-      <li class="list__item--ok">
         Remote desktop utility:
-        <a href="https://wiki.gnome.org/Projects/Mutter/RemoteDesktop">gnome-remote-desktop</a>,
+        <a href="https://wiki.gnome.org/Projects/Mutter/RemoteDesktop">GNOME Remote Desktop</a>,
         <a href="https://github.com/any1/wayvnc">wayvnc</a>
       </li>
       <li class="list__item--ok">
         Screen lock tool:
         <a href="https://github.com/swaywm/swaylock">swaylock</a>,
-        <a href="https://github.com/ifreund/waylock">waylock</a>
+        <a href="https://github.com/ifreund/waylock">Waylock</a>
       </li>
       <li class="list__item--ok">
         Screen recording tool:
-        <a href="https://github.com/obsproject/obs-studio">OBS</a> (with <a href="https://hg.sr.ht/~scoopta/wlrobs">a plugin</a>),
+        <a href="https://obsproject.com">OBS Studio</a> (with <a href="https://hg.sr.ht/~scoopta/wlrobs">a plugin</a>),
         <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>
       </li>
       <li class="list__item--ok">
         Screen sharing:
-        <a href="https://github.com/emersion/xdg-desktop-portal-wlr/wiki/Screencast-Compatibility">xdg-desktop-portal-wlr</a>
+        <a href="https://github.com/emersion/xdg-desktop-portal-wlr">xdg-desktop-portal-wlr</a>
       </li>
       <li class="list__item--ok">
         Screenshot tool:
-        <a href="https://flameshot.org/">flameshot</a>,
+        <a href="https://flameshot.org/">Flameshot</a>,
         <a href="https://github.com/emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
-        <a href="https://gitlab.com/WhyNotHugo/shotman">shotman</a>,
+        <a href="https://gitlab.com/WhyNotHugo/shotman">Shotman</a>,
         <a href="https://github.com/jtheoof/swappy">swappy</a>
       </li>
       <li class="list__item--ok">
         Stacking compositor:
         <a href="https://hikari.acmelabs.space">hikari</a>,
-        <a href="https://github.com/johanmalm/labwc">labwc</a>,
-        <a href="https://github.com/lirios/shell">liri-shell</a>
+        <a href="https://github.com/johanmalm/labwc">Labwc</a>,
+        <a href="https://github.com/lirios/shell">Liri shell</a>
       </li>
       <li class="list__item--ok">
         Status bar:
-        <a href="https://github.com/hcsubser/hybridbar">hybridbar</a>,
+        <a href="https://github.com/hcsubser/hybridbar">Hybridbar</a>,
         <a href="https://github.com/nwg-piotr/nwg-panel">nwg-panel</a>,
         <a href="https://github.com/Alexays/Waybar">Waybar</a>,
-        <a href="https://gitlab.com/dnkl/yambar">yambar</a>
+        <a href="https://gitlab.com/dnkl/yambar">Yambar</a>
       </li>
       <li class="list__item--ok">
         System monitoring widget:
@@ -140,17 +139,17 @@
         Terminal:
         <a href="https://github.com/alacritty/alacritty">Alacritty</a>,
         <a href="https://codeberg.org/dnkl/foot/">foot</a>,
-        <a href="https://help.gnome.org/users/gnome-terminal/stable/">gnome-terminal</a>,
-        <a href="https://sw.kovidgoyal.net/kitty/">Kitty</a>,
+        <a href="https://wiki.gnome.org/Apps/Terminal">GNOME Terminal</a>,
+        <a href="https://sw.kovidgoyal.net/kitty/">kitty</a>,
         <a href="https://github.com/KDE/konsole">Konsole</a>,
         <a href="https://launchpad.net/sakura">Sakura</a>
       </li>
       <li class="list__item--ok">
         Tiling compositor:
         <a href="https://github.com/djpohly/dwl">dwl</a>,
-        <a href="https://github.com/ifreund/river">River</a>,
+        <a href="https://github.com/ifreund/river">river</a>,
         <a href="https://github.com/swaywm/sway">Sway</a>,
-        <a href="https://github.com/michaelforney/velox">Velox</a>
+        <a href="https://github.com/michaelforney/velox">velox</a>
       </li>
       <li class="list__item--ok">
         User input simulating tool:
@@ -159,7 +158,7 @@
       </li>
       <li class="list__item--ok">
         Video player:
-        <a href="https://github.com/mpv-player/mpv">mpv</a>
+        <a href="https://mpv.io">mpv</a>
       </li>
       <li class="list__item--ok">
         Wallpaper manager:
@@ -170,8 +169,8 @@
       <li class="list__item--ok">
         Web browser:
         <a href="https://www.chromium.org/">Chromium</a>,
-        <a href="https://wiki.gnome.org/Apps/Web">Epiphany</a>,
         <a href="https://www.mozilla.org/firefox/">Firefox</a>,
+        <a href="https://wiki.gnome.org/Apps/Web">GNOME Web (epiphany)</a>,
         <a href="https://qutebrowser.org/">qutebrowser</a>
         </small>
       </li>


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
