### PR TITLE
fix: OBS now works without the need of a plugin

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -104,7 +104,7 @@
       </li>
       <li class="list__item--ok">
         Screen recording tool:
-        <a href="https://obsproject.com">OBS Studio</a> (with <a href="https://hg.sr.ht/~scoopta/wlrobs">a plugin</a>),
+        <a href="https://obsproject.com">OBS Studio</a>,
         <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
## Description

Removes text about the OBS plugin. Since the latest release now works without a plugin.

fixes #71

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
