### PR TITLE
feat: add Okular document viewer

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -48,6 +48,7 @@
         Document viewer:
         <a href="https://github.com/mate-desktop/atril">Atril</a>,
         <a href="https://wiki.gnome.org/Apps/Evince">Evince</a>,
+        <a href="https://okular.kde.org/">Okular</a>,
         <a href="https://git.pwmt.org/pwmt/zathura">zathura</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
Fixes #100

## Description

I added Okular

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
