### PR TITLE
Include many Wayland tools

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -114,9 +114,7 @@
         <a href="https://github.com/xlmnxp/blue-recorder">Blue Recorder</a>,
         <a href="https://github.com/SeaDve/Kooha">Kooha</a>,
         <a href="https://obsproject.com">OBS Studio</a>,
-        <a href="https://github.com/phw/peek">Peek</a>,
         <a href="https://github.com/amikha1lov/RecApp">RecApp</a>,
-        <a href="https://github.com/foxcpp/ssr-wlroots">ssr-wlroots</a>,
         <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>
       </li>
       <li class="list__item--ok">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -42,6 +42,7 @@
       <li class="list__item--ok">
         Dock:
         <a href="https://sr.ht/~leon_plickat/LavaLauncher/">LavaLauncher</a>,
+	<a href="https://invent.kde.org/plasma/latte-dock">Latte Dock</a>,
         <a href="https://github.com/nwg-piotr/nwg-dock">nwg-dock</a>
       </li>
       <li class="list__item--ok">
@@ -65,7 +66,11 @@
       <li class="list__item--ok">
         Image viewer:
         <a href="https://wiki.gnome.org/Apps/EyeOfGnome">GNOME Image Viewer (eog)</a>,
-        <a href="https://github.com/eXeC64/imv">imv</a>
+	<a href="https://invent.kde.org/graphics/gwenview">Gwenview</a>,
+        <a href="https://github.com/eXeC64/imv">imv</a>,
+	<a href="https://invent.kde.org/graphics/koko">Koko</a>,
+	<a href="https://github.com/occivink/mpv-image-viewer">mvi</a>,
+	<a href="https://invent.kde.org/maui/pix">Pix</a>
       </li>
       <li class="list__item--ok">
         Login manager:
@@ -85,8 +90,14 @@
       </li>
       <li class="list__item--ok">
         Output/display configuration tool:
+	<a href="https://gitlab.com/kwinft/disman">Disman</a>,
         <a href="https://github.com/emersion/kanshi">kanshi</a>,
+	<a href="https://invent.kde.org/plasma/kscreen">KScreen</a>,
+	<a href="https://invent.kde.org/plasma/libkscreen">kscreen-doctor</a>,
+	<a href="https://github.com/swaywm/sway">swaymsg</a>,
+	<a href="https://github.com/xyproto/wallutils">wallutils</a>,
         <a href="https://github.com/luispabon/wdisplays">wdisplays</a>,
+	<a href="https://github.com/atx/wlay">wlay</a>,
         <a href="https://github.com/emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">
@@ -96,6 +107,7 @@
       <li class="list__item--ok">
         Remote desktop utility:
         <a href="https://wiki.gnome.org/Projects/Mutter/RemoteDesktop">GNOME Remote Desktop</a>,
+        <a href="https://invent.kde.org/network/krfb">Krfb</a>,
         <a href="https://github.com/any1/wayvnc">wayvnc</a>
       </li>
       <li class="list__item--ok">
@@ -105,11 +117,22 @@
       </li>
       <li class="list__item--ok">
         Screen recording tool:
+        <a href="https://github.com/xlmnxp/blue-recorder">Blue Recorder</a>,
+        <a href="https://gitlab.gnome.org/GNOME/mutter">GNOME ScreenCast</a>,
+        <a href="https://github.com/mhsabbagh/green-recorder">Green Recorder (Unmaintained)</a>,
+        <a href="https://github.com/SeaDve/Kooha">Kooha</a>,
         <a href="https://obsproject.com">OBS Studio</a>,
-        <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>
+        <a href="https://github.com/phw/peek">Peek</a>,
+        <a href="https://github.com/amikha1lov/RecApp">RecApp</a>,
+        <a href="https://github.com/foxcpp/ssr-wlroots">simplescreenrecorder-wlroots</a>,
+        <a href="https://invent.kde.org/bharadwaj-raju/wayrec">WayRec</a>,
+        <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>,
+        <a href="https://hg.sr.ht/~scoopta/wlrobs">wlrobs</a>
       </li>
       <li class="list__item--ok">
         Screen sharing:
+        <a href="https://github.com/flatpak/xdg-desktop-portal-gtk">xdg-desktop-portal-gtk</a>,
+        <a href="https://invent.kde.org/plasma/xdg-desktop-portal-kde">xdg-desktop-portal-kde</a>,
         <a href="https://github.com/emersion/xdg-desktop-portal-wlr">xdg-desktop-portal-wlr</a>
       </li>
       <li class="list__item--ok">
@@ -117,6 +140,7 @@
         <a href="https://flameshot.org/">Flameshot</a>,
         <a href="https://github.com/emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
         <a href="https://gitlab.com/WhyNotHugo/shotman">Shotman</a>,
+        <a href="https://invent.kde.org/graphics/spectacle">Spectacle</a>,
         <a href="https://github.com/jtheoof/swappy">swappy</a>
       </li>
       <li class="list__item--ok">
@@ -139,11 +163,16 @@
       <li class="list__item--ok">
         Terminal:
         <a href="https://github.com/alacritty/alacritty">Alacritty</a>,
+        <a href="https://github.com/andir/ate">Ate</a>,
         <a href="https://codeberg.org/dnkl/foot/">foot</a>,
+        <a href="https://github.com/Keruspe/Germinal">Germinal</a>,
         <a href="https://wiki.gnome.org/Apps/Terminal">GNOME Terminal</a>,
+        <a href="https://github.com/ii8/havoc">Havoc</a>,
         <a href="https://sw.kovidgoyal.net/kitty/">kitty</a>,
         <a href="https://github.com/KDE/konsole">Konsole</a>,
-        <a href="https://launchpad.net/sakura">Sakura</a>
+        <a href="https://launchpad.net/sakura">Sakura</a>,
+        <a href="https://github.com/thestinger/termite">Termite</a>,
+        <a href="https://github.com/majestrate/wterm">wterm</a>
       </li>
       <li class="list__item--ok">
         Tiling compositor:
@@ -159,17 +188,22 @@
       </li>
       <li class="list__item--ok">
         Video player:
+        <a href="https://invent.kde.org/multimedia/haruna">Haruna</a>,
         <a href="https://mpv.io">mpv</a>
       </li>
       <li class="list__item--ok">
         Wallpaper manager:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
+        <a href="https://github.com/vilhalmer/oguri">Oguri</a>,
+        <a href="https://github.com/GhostNaN/mpvpaper">mpvpaper</a>,
+        <a href="https://invent.kde.org/plasma/plasma-workspace">plasma-apply-wallpaperimage</a>,
         <a href="https://github.com/swaywm/swaybg">swaybg</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>
       </li>
       <li class="list__item--ok">
         Web browser:
         <a href="https://www.chromium.org/">Chromium</a>,
+        <a href="https://www.falkon.org/">Falkon</a>,
         <a href="https://www.mozilla.org/firefox/">Firefox</a>,
         <a href="https://wiki.gnome.org/Apps/Web">GNOME Web (epiphany)</a>,
         <a href="https://qutebrowser.org/">qutebrowser</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -42,7 +42,7 @@
       <li class="list__item--ok">
         Dock:
         <a href="https://sr.ht/~leon_plickat/LavaLauncher/">LavaLauncher</a>,
-	<a href="https://invent.kde.org/plasma/latte-dock">Latte Dock</a>,
+        <a href="https://invent.kde.org/plasma/latte-dock">Latte Dock</a>,
         <a href="https://github.com/nwg-piotr/nwg-dock">nwg-dock</a>
       </li>
       <li class="list__item--ok">
@@ -66,11 +66,11 @@
       <li class="list__item--ok">
         Image viewer:
         <a href="https://wiki.gnome.org/Apps/EyeOfGnome">GNOME Image Viewer (eog)</a>,
-	<a href="https://invent.kde.org/graphics/gwenview">Gwenview</a>,
+        <a href="https://invent.kde.org/graphics/gwenview">Gwenview</a>,
         <a href="https://github.com/eXeC64/imv">imv</a>,
-	<a href="https://invent.kde.org/graphics/koko">Koko</a>,
-	<a href="https://github.com/occivink/mpv-image-viewer">mvi</a>,
-	<a href="https://invent.kde.org/maui/pix">Pix</a>
+        <a href="https://invent.kde.org/graphics/koko">Koko</a>,
+        <a href="https://github.com/occivink/mpv-image-viewer">mvi</a>,
+        <a href="https://invent.kde.org/maui/pix">Pix</a>
       </li>
       <li class="list__item--ok">
         Login manager:
@@ -90,14 +90,14 @@
       </li>
       <li class="list__item--ok">
         Output/display configuration tool:
-	<a href="https://gitlab.com/kwinft/disman">Disman</a>,
+        <a href="https://gitlab.com/kwinft/disman">Disman</a>,
         <a href="https://github.com/emersion/kanshi">kanshi</a>,
-	<a href="https://invent.kde.org/plasma/kscreen">KScreen</a>,
-	<a href="https://invent.kde.org/plasma/libkscreen">kscreen-doctor</a>,
-	<a href="https://github.com/swaywm/sway">swaymsg</a>,
-	<a href="https://github.com/xyproto/wallutils">wallutils</a>,
+        <a href="https://invent.kde.org/plasma/kscreen">KScreen</a>,
+        <a href="https://invent.kde.org/plasma/libkscreen">kscreen-doctor</a>,
+        <a href="https://github.com/swaywm/sway">swaymsg</a>,
+        <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/luispabon/wdisplays">wdisplays</a>,
-	<a href="https://github.com/atx/wlay">wlay</a>,
+        <a href="https://github.com/atx/wlay">wlay</a>,
         <a href="https://github.com/emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">
@@ -124,7 +124,7 @@
         <a href="https://obsproject.com">OBS Studio</a>,
         <a href="https://github.com/phw/peek">Peek</a>,
         <a href="https://github.com/amikha1lov/RecApp">RecApp</a>,
-        <a href="https://github.com/foxcpp/ssr-wlroots">simplescreenrecorder-wlroots</a>,
+        <a href="https://github.com/foxcpp/ssr-wlroots">ssr-wlroots</a>,
         <a href="https://invent.kde.org/bharadwaj-raju/wayrec">WayRec</a>,
         <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>,
         <a href="https://hg.sr.ht/~scoopta/wlrobs">wlrobs</a>
@@ -167,12 +167,12 @@
         <a href="https://codeberg.org/dnkl/foot/">foot</a>,
         <a href="https://github.com/Keruspe/Germinal">Germinal</a>,
         <a href="https://wiki.gnome.org/Apps/Terminal">GNOME Terminal</a>,
-        <a href="https://github.com/ii8/havoc">Havoc</a>,
+        <a href="https://github.com/ii8/havoc">havoc</a>,
         <a href="https://sw.kovidgoyal.net/kitty/">kitty</a>,
         <a href="https://github.com/KDE/konsole">Konsole</a>,
         <a href="https://launchpad.net/sakura">Sakura</a>,
-        <a href="https://github.com/thestinger/termite">Termite</a>,
-        <a href="https://github.com/majestrate/wterm">wterm</a>
+        <a href="https://github.com/thestinger/termite">Termite (Unmaintained)</a>,
+        <a href="https://github.com/majestrate/wterm">wterm (Unmaintained)</a>
       </li>
       <li class="list__item--ok">
         Tiling compositor:
@@ -194,8 +194,8 @@
       <li class="list__item--ok">
         Wallpaper manager:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
-        <a href="https://github.com/vilhalmer/oguri">Oguri</a>,
-        <a href="https://github.com/GhostNaN/mpvpaper">mpvpaper</a>,
+        <a href="https://github.com/vilhalmer/oguri">oguri</a>,
+        <a href="https://github.com/GhostNaN/mpvpaper">MPVPaper</a>,
         <a href="https://invent.kde.org/plasma/plasma-workspace">plasma-apply-wallpaperimage</a>,
         <a href="https://github.com/swaywm/swaybg">swaybg</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -67,10 +67,7 @@
         Image viewer:
         <a href="https://wiki.gnome.org/Apps/EyeOfGnome">GNOME Image Viewer (eog)</a>,
         <a href="https://invent.kde.org/graphics/gwenview">Gwenview</a>,
-        <a href="https://github.com/eXeC64/imv">imv</a>,
-        <a href="https://invent.kde.org/graphics/koko">Koko</a>,
-        <a href="https://github.com/occivink/mpv-image-viewer">mvi</a>,
-        <a href="https://invent.kde.org/maui/pix">Pix</a>
+        <a href="https://github.com/eXeC64/imv">imv</a>
       </li>
       <li class="list__item--ok">
         Login manager:
@@ -92,12 +89,9 @@
         Output/display configuration tool:
         <a href="https://gitlab.com/kwinft/disman">Disman</a>,
         <a href="https://github.com/emersion/kanshi">kanshi</a>,
-        <a href="https://invent.kde.org/plasma/kscreen">KScreen</a>,
         <a href="https://invent.kde.org/plasma/libkscreen">kscreen-doctor</a>,
-        <a href="https://github.com/swaywm/sway">swaymsg</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/luispabon/wdisplays">wdisplays</a>,
-        <a href="https://github.com/atx/wlay">wlay</a>,
         <a href="https://github.com/emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">
@@ -118,16 +112,12 @@
       <li class="list__item--ok">
         Screen recording tool:
         <a href="https://github.com/xlmnxp/blue-recorder">Blue Recorder</a>,
-        <a href="https://gitlab.gnome.org/GNOME/mutter">GNOME ScreenCast</a>,
-        <a href="https://github.com/mhsabbagh/green-recorder">Green Recorder (Unmaintained)</a>,
         <a href="https://github.com/SeaDve/Kooha">Kooha</a>,
         <a href="https://obsproject.com">OBS Studio</a>,
         <a href="https://github.com/phw/peek">Peek</a>,
         <a href="https://github.com/amikha1lov/RecApp">RecApp</a>,
         <a href="https://github.com/foxcpp/ssr-wlroots">ssr-wlroots</a>,
-        <a href="https://invent.kde.org/bharadwaj-raju/wayrec">WayRec</a>,
-        <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>,
-        <a href="https://hg.sr.ht/~scoopta/wlrobs">wlrobs</a>
+        <a href="https://github.com/ammen99/wf-recorder">wf-recorder</a>
       </li>
       <li class="list__item--ok">
         Screen sharing:
@@ -170,9 +160,7 @@
         <a href="https://github.com/ii8/havoc">havoc</a>,
         <a href="https://sw.kovidgoyal.net/kitty/">kitty</a>,
         <a href="https://github.com/KDE/konsole">Konsole</a>,
-        <a href="https://launchpad.net/sakura">Sakura</a>,
-        <a href="https://github.com/thestinger/termite">Termite (Unmaintained)</a>,
-        <a href="https://github.com/majestrate/wterm">wterm (Unmaintained)</a>
+        <a href="https://launchpad.net/sakura">Sakura</a>
       </li>
       <li class="list__item--ok">
         Tiling compositor:


### PR DESCRIPTION
## Description

This is a major inclusion of wayland-native tools.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
