### PR TITLE
feat: add wlopm to output configuration section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -87,6 +87,7 @@
         Output/display configuration tool:
         <a href="https://github.com/emersion/kanshi">kanshi</a>,
         <a href="https://github.com/luispabon/wdisplays">wdisplays</a>,
+        <a href="https://sr.ht/~leon_plickat/wlopm">wlopm</a>,
         <a href="https://github.com/emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
## Description

Short description of the changes:

This adds wlopm to list of output configuration tools.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
