### PR TITLE
Update URLs for kanshi and wlr-randr

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -81,11 +81,11 @@
       </li>
       <li class="list__item--ok">
         Output/display configuration tool:
-        <a href="https://github.com/emersion/kanshi">kanshi</a>,
+        <a href="https://sr.ht/~emersion/kanshi/">kanshi</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/artizirk/wdisplays">wdisplays</a>,
         <a href="https://sr.ht/~leon_plickat/wlopm">wlopm</a>,
-        <a href="https://github.com/emersion/wlr-randr">wlr-randr</a>
+        <a href="https://sr.ht/~emersion/wlr-randr/">wlr-randr</a>
       </li>
       <li class="list__item--ok">
         Power menu:


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [n/a] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [n/a] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [n/a] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [n/a] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [n/a] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
