### PR TITLE
feat: add opera browser (fixes #111)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -176,6 +176,7 @@
         <a href="https://www.chromium.org/">Chromium</a>,
         <a href="https://www.mozilla.org/firefox/">Firefox</a>,
         <a href="https://nyxt.atlas.engineer">Nyxt</a>,
+        <a href="https://www.opera.com/">Opera</a>,
         <a href="https://qutebrowser.org/">qutebrowser</a>
         </small>
       </li>


### PR DESCRIPTION
## Description

Just adds Opera, solving #111 

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
