### PR TITLE
feat: add Inkscape (solves #78)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -60,6 +60,10 @@
         <a href="https://sr.ht/~kennylevinsen/wlsunset/">wlsunset</a>
       </li>
       <li class="list__item--ok">
+        Image editor:
+        <a href="https://inkscape.org/">Inkscape</a>
+      </li>
+      <li class="list__item--ok">
         Image viewer:
         <a href="https://github.com/eXeC64/imv">imv</a>,
         <a href="https://nomacs.org/">nomacs</a>


### PR DESCRIPTION
## Description

Adds an "Image editor"  session with Inkscape on it. Solves #78 

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
