### PR TITLE
feat: add Terminator (solves #75)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -144,6 +144,7 @@
         <a href="https://sw.kovidgoyal.net/kitty/">kitty</a>,
         <a href="https://github.com/realh/roxterm">ROXTerm</a>,
         <a href="https://launchpad.net/sakura">Sakura</a>,
+        <a href="https://terminator-gtk3.readthedocs.io/en/latest/">Terminator</a>,
         <a href="https://gnunn1.github.io/tilix-web/">Tilix</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
## Description
Adds `Terminator` to the terminal session

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
