### PR TITLE
feat: add email section (solves #43)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,6 +51,10 @@
         <a href="https://git.pwmt.org/pwmt/zathura">zathura</a>
       </li>
       <li class="list__item--ok">
+        Email client (GUI):
+        <a href="https://help.gnome.org/users/evolution/stable/">Evolution</a>,
+        <a href="https://www.thunderbird.net/en-US/">Thunderbird</a>,
+      <li class="list__item--ok">
         File manager:
         <a href="https://github.com/linuxmint/nemo">Nemo</a>
       </li>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -54,6 +54,7 @@
         Email client (GUI):
         <a href="https://help.gnome.org/users/evolution/stable/">Evolution</a>,
         <a href="https://www.thunderbird.net/en-US/">Thunderbird</a>,
+      </li>
       <li class="list__item--ok">
         File manager:
         <a href="https://github.com/linuxmint/nemo">Nemo</a>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -53,7 +53,7 @@
       <li class="list__item--ok">
         Email client (GUI):
         <a href="https://help.gnome.org/users/evolution/stable/">Evolution</a>,
-        <a href="https://www.thunderbird.net/en-US/">Thunderbird</a>,
+        <a href="https://www.thunderbird.net/en-US/">Thunderbird</a>
       </li>
       <li class="list__item--ok">
         File manager:


### PR DESCRIPTION
## Description

Adds an "Email client (GUI)" session with thunderbird and evolution (both tested by me to ensure they work with wayland)

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
