### PR TITLE
feat: add keyboard remapper (closes #67)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -75,7 +75,7 @@
       </li>
       <li class="list__item--ok">
         Keyboard remapper:
-        <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>,
+        <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>
       </li>
       <li class="list__item--ok">
         Login manager:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -65,6 +65,10 @@
         <a href="https://nomacs.org/">nomacs</a>
       </li>
       <li class="list__item--ok">
+        Keyboard remapper:
+        <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>,
+      </li>
+      <li class="list__item--ok">
         Login manager:
         <a href="https://sr.ht/~kennylevinsen/greetd/">greetd</a>,
         <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>


### PR DESCRIPTION
## Description

Adds a "Keyboard remapper" session (a must have for 60% keuboard users). Solves #67 

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
