### PR TITLE
feat: add keyd and kmonad in keyboard remapper section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -77,7 +77,7 @@
         Keyboard remapper:
         <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>
         <a href="https://github.com/rvaiya/keyd"keyd</a>
-        <a href="https://github.com/kmonad/kmonad"kmonad</a>
+        <a href="https://github.com/kmonad/kmonad"KMonad</a>
       </li>
       <li class="list__item--ok">
         Login manager:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -77,8 +77,8 @@
       </li>
       <li class="list__item--ok">
         Keyboard remapper:
-        <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>
-        <a href="https://github.com/rvaiya/keyd"keyd</a>
+        <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>,
+        <a href="https://github.com/rvaiya/keyd"keyd</a>,
         <a href="https://github.com/kmonad/kmonad"KMonad</a>
       </li>
       <li class="list__item--ok">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -76,6 +76,8 @@
       <li class="list__item--ok">
         Keyboard remapper:
         <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>
+        <a href="https://github.com/rvaiya/keyd"keyd</a>
+        <a href="https://github.com/kmonad/kmonad"kmonad</a>
       </li>
       <li class="list__item--ok">
         Login manager:


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
