### PR TITLE
feat: add SwayNotificationCenter to Notification daemon section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -91,6 +91,7 @@
         <a href="https://dunst-project.org">Dunst</a>,
         <a href="https://codeberg.org/dnkl/fnott">Fnott</a>,
         <a href="https://github.com/emersion/mako">mako</a>
+        <a href="https://github.com/ErikReider/SwayNotificationCenter">SwayNotificationCenter</a>
       </li>
       <li class="list__item--ok">
         Output/display configuration tool:


### PR DESCRIPTION
## Description

Added SwayNotificationCenter to the Notification daemon section

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
