### PR TITLE
feat: add Qtile to tiling compositor list

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -164,6 +164,7 @@
       <li class="list__item--ok">
         Tiling compositor:
         <a href="https://github.com/djpohly/dwl">dwl</a>,
+        <a href="https://www.qtile.org">Qtile</a>,
         <a href="https://github.com/ifreund/river">river</a>,
         <a href="https://github.com/swaywm/sway">Sway</a>,
         <a href="https://github.com/michaelforney/velox">velox</a>,


### PR DESCRIPTION
## Description

Short description of the changes: Added Qtile window manager to the list since it can now be run as a Wayland compositor

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
