### PR TITLE
feat: add WezTerm to the list of terminals

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -160,7 +160,8 @@
         <a href="https://github.com/realh/roxterm">ROXTerm</a>,
         <a href="https://launchpad.net/sakura">Sakura</a>,
         <a href="https://terminator-gtk3.readthedocs.io/en/latest/">Terminator</a>,
-        <a href="https://gnunn1.github.io/tilix-web/">Tilix</a>
+        <a href="https://gnunn1.github.io/tilix-web/">Tilix</a>,
+        <a href="https://wezfurlong.org/wezterm/">WezTerm</a>
       </li>
       <li class="list__item--ok">
         Tiling compositor:


### PR DESCRIPTION
WezTerm, a Rust terminal emulator, provides OpenGL rendering, tabs, split panes, multiplexing, font ligatures, support for many modern terminal protocol extensions (hyperlinks, true color, iTerm2 inline images, etc.), all backed by a powerful and flexible Lua-based configuration.

## Description

Short description of the changes:

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
