### PR TITLE
feat: add nwg-displays to list of output managers

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -96,11 +96,12 @@
       </li>
       <li class="list__item--ok">
         Output/display configuration tool:
-        <a href="https://sr.ht/~emersion/kanshi/">kanshi</a>,
+        <a href="https://sr.ht/~emersion/kanshi">kanshi</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/artizirk/wdisplays">wdisplays</a>,
         <a href="https://sr.ht/~leon_plickat/wlopm">wlopm</a>,
-        <a href="https://sr.ht/~emersion/wlr-randr/">wlr-randr</a>
+        <a href="https://sr.ht/~emersion/wlr-randr">wlr-randr</a>,
+        <a href="https://github.com/nwg-piotr/nwg-displays">nwg-displays</a>
       </li>
       <li class="list__item--ok">
         Power menu:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -97,11 +97,11 @@
       <li class="list__item--ok">
         Output/display configuration tool:
         <a href="https://sr.ht/~emersion/kanshi">kanshi</a>,
+        <a href="https://github.com/nwg-piotr/nwg-displays">nwg-displays</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/artizirk/wdisplays">wdisplays</a>,
         <a href="https://sr.ht/~leon_plickat/wlopm">wlopm</a>,
-        <a href="https://sr.ht/~emersion/wlr-randr">wlr-randr</a>,
-        <a href="https://github.com/nwg-piotr/nwg-displays">nwg-displays</a>
+        <a href="https://sr.ht/~emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">
         Power menu:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -72,7 +72,7 @@
         Image viewer:
         <a href="https://github.com/eXeC64/imv">imv</a>,
         <a href="https://nomacs.org/">nomacs</a>,
-	<a href="https://github.com/artemsen/swayimg">swayimg</a>
+        <a href="https://github.com/artemsen/swayimg">swayimg</a>
       </li>
       <li class="list__item--ok">
         Keyboard remapper:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -71,7 +71,8 @@
       <li class="list__item--ok">
         Image viewer:
         <a href="https://github.com/eXeC64/imv">imv</a>,
-        <a href="https://nomacs.org/">nomacs</a>
+        <a href="https://nomacs.org/">nomacs</a>,
+	<a href="https://github.com/artemsen/swayimg">swayimg</a>
       </li>
       <li class="list__item--ok">
         Keyboard remapper:


### PR DESCRIPTION
## Description

Short description of the changes:
Add nwg-displays to list of output managers and delete some unnecessary slashes in other links

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
