### PR TITLE
feat: add wmenu to list of application launchers

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -17,6 +17,7 @@
         <a href="https://github.com/oknozor/onagre">Onagre</a>,
         <a href="https://github.com/lbonn/rofi">Rofi (lbonn's fork)</a>,
         <a href="https://ulauncher.io">Ulauncher</a>,
+        <a href="https://sr.ht/~adnano/wmenu/">wmenu</a>,
         <a href="https://hg.sr.ht/~scoopta/wofi">Wofi</a>,
         <a href="https://github.com/l4l/yofi">yofi</a>
       </li>


### PR DESCRIPTION
## Description

wmenu is a dmenu-fork adapted to work on wayland. Added the project link to the list of application launchers. It has no website.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
