### PR TITLE
Add xremap

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -82,7 +82,7 @@
         <a href="https://gitlab.com/interception/linux/tools">Interception Tools</a>,
         <a href="https://github.com/samvel1024/kbct">kbct</a>,
         <a href="https://github.com/rvaiya/keyd">keyd</a>,
-        <a href="https://github.com/kmonad/kmonad">KMonad</a>
+        <a href="https://github.com/kmonad/kmonad">KMonad</a>,
         <a href="https://github.com/k0kubun/xremap">xremap</a>
       </li>
       <li class="list__item--ok">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -83,6 +83,7 @@
         <a href="https://github.com/samvel1024/kbct">kbct</a>,
         <a href="https://github.com/rvaiya/keyd">keyd</a>,
         <a href="https://github.com/kmonad/kmonad">KMonad</a>
+        <a href="https://github.com/k0kubun/xremap">Xremap</a>
       </li>
       <li class="list__item--ok">
         Login manager:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -83,7 +83,7 @@
         <a href="https://github.com/samvel1024/kbct">kbct</a>,
         <a href="https://github.com/rvaiya/keyd">keyd</a>,
         <a href="https://github.com/kmonad/kmonad">KMonad</a>
-        <a href="https://github.com/k0kubun/xremap">Xremap</a>
+        <a href="https://github.com/k0kubun/xremap">xremap</a>
       </li>
       <li class="list__item--ok">
         Login manager:


### PR DESCRIPTION
## Description

Added xremap, a keyboard remapper that's been running flawlessly on Wayland

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [\*] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.). Both Xremap and xremap is used in the README. I went with the project name's casing
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
