### PR TITLE
Updates imv project URL

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -71,7 +71,7 @@
       </li>
       <li class="list__item--ok">
         Image viewer:
-        <a href="https://github.com/eXeC64/imv">imv</a>,
+        <a href="https://sr.ht/~exec64/imv/">imv</a>,
         <a href="https://nomacs.org/">nomacs</a>,
         <a href="https://github.com/artemsen/swayimg">swayimg</a>
       </li>


### PR DESCRIPTION
## Description
imv moved from [Github](https://github.com/eXeC64/imv) to [sr.ht](https://sr.ht/~exec64/imv/)

Short description of the changes:

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
