### PR TITLE
Mention global hotkeys and PTT

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -218,6 +218,10 @@
         Color management and HDR:
         <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Protocol in development</a>
       </li>
+      <li class="list__item--ko">
+        Temporary global hotkeys and PTT:
+        <a href="https://github.com/flatpak/xdg-desktop-portal/issues/624">No official plan yet</a>
+      </li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Description

Add the global hotkeys issue

I'm not aware of a better source to link. The issue is discussed all over the place, but there doesn't seem to be a protocol proposal.

## Checklist

I have:

- [ ] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ ] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
