### PR TITLE
Add Gimp and Krita to Image editor

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -67,8 +67,8 @@
       </li>
       <li class="list__item--ok">
         Image editor:
-        <a href="https://gimp.org/">Gimp</a>
-	<a href="https://inkscape.org/">Inkscape</a>
+        <a href="https://gimp.org/">Gimp</a>,
+        <a href="https://inkscape.org/">Inkscape</a>,
         <a href="https://krita.org/">Krita</a>
       </li>
       <li class="list__item--ok">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -67,7 +67,9 @@
       </li>
       <li class="list__item--ok">
         Image editor:
-        <a href="https://inkscape.org/">Inkscape</a>
+        <a href="https://gimp.org/">Gimp</a>
+	<a href="https://inkscape.org/">Inkscape</a>
+        <a href="https://krita.org/">Krita</a>
       </li>
       <li class="list__item--ok">
         Image viewer:


### PR DESCRIPTION
## Description

Add Gimp and Krita to Image editor

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")