### PR TITLE
feat: add cliphist

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -23,6 +23,7 @@
       </li>
       <li class="list__item--ok">
         Clipboard manager:
+        <a href="https://github.com/sentriz/cliphist">cliphist</a>,
         <a href="https://github.com/yory8/clipman">Clipman</a>,
         <a href="https://github.com/bugaevc/wl-clipboard">wl-clipboard</a>
       </li>


### PR DESCRIPTION
## Description


hi! this add [cliphist](https://github.com/sentriz/cliphist) as a clipboard manager

quite similar to clipman which is already there (and quite a nice tool), but I personally prefer cliphist because 
- it makes no assumptions about a picker tool. you can use whatever you like
- clipboard is preserved byte for byte, no hidden character messups
- images/non-text also work

also I think manjaro sway edition also use it now


thanks! 

## Checklist 

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, <https://mpv.io>) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
