### PR TITLE
feat: add Hyprland to the tiling compositor list (closes #139)

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -179,6 +179,7 @@
       <li class="list__item--ok">
         Tiling compositor:
         <a href="https://github.com/djpohly/dwl">dwl</a>,
+        <a href="https://github.com/hyprwm/Hyprland">Hyprland</a>,
         <a href="https://www.qtile.org">Qtile</a>,
         <a href="https://github.com/ifreund/river">river</a>,
         <a href="https://github.com/swaywm/sway">Sway</a>,


### PR DESCRIPTION
## Description

Short description of the changes: Adds Hyprland to the tiling compositor list and solves [#139](https://github.com/mpsq/arewewaylandyet/issues/139)

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
