### PR TITLE
feat: add hyprpaper and hyprpicker

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -31,6 +31,7 @@
         Color picker:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
         <a href="https://github.com/emersion/grim">grim</a>
+        <a href="https://github.com/hyprwm/hyprpicker">hyprpicker</a>
       </li>
       <li class="list__item--ok">
         Compiz support:
@@ -199,6 +200,7 @@
       <li class="list__item--ok">
         Wallpaper manager:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
+        <a href="https://github.com/hyprwm/hyprpaper">hyprpaper</a>
         <a href="https://github.com/GhostNaN/mpvpaper">MPVPaper</a>,
         <a href="https://github.com/vilhalmer/oguri">oguri</a>,
         <a href="https://github.com/swaywm/swaybg">swaybg</a>,

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,7 +30,7 @@
       <li class="list__item--ok">
         Color picker:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
-        <a href="https://github.com/emersion/grim">grim</a>
+        <a href="https://github.com/emersion/grim">grim</a>,
         <a href="https://github.com/hyprwm/hyprpicker">hyprpicker</a>
       </li>
       <li class="list__item--ok">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -200,7 +200,7 @@
       <li class="list__item--ok">
         Wallpaper manager:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
-        <a href="https://github.com/hyprwm/hyprpaper">hyprpaper</a>
+        <a href="https://github.com/hyprwm/hyprpaper">hyprpaper</a>,
         <a href="https://github.com/GhostNaN/mpvpaper">MPVPaper</a>,
         <a href="https://github.com/vilhalmer/oguri">oguri</a>,
         <a href="https://github.com/swaywm/swaybg">swaybg</a>,


### PR DESCRIPTION
## Description

Short description of the changes:
Add hyprpaper wallpaper manager and hyprpicker color picker.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
