### PR TITLE
feat: add gcolor3

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,7 +30,7 @@
       <li class="list__item--ok">
         Color picker:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
-        <a href="https://gitlab.gnome.org/World/gcolor3">gcolor3</a>
+        <a href="https://gitlab.gnome.org/World/gcolor3">gcolor3</a>,
         <a href="https://github.com/emersion/grim">grim</a>,
         <a href="https://github.com/hyprwm/hyprpicker">hyprpicker</a>
       </li>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,6 +30,7 @@
       <li class="list__item--ok">
         Color picker:
         <a href="https://github.com/nwg-piotr/azote">Azote</a>,
+        <a href="https://gitlab.gnome.org/World/gcolor3">gcolor3</a>
         <a href="https://github.com/emersion/grim">grim</a>,
         <a href="https://github.com/hyprwm/hyprpicker">hyprpicker</a>
       </li>


### PR DESCRIPTION
## Description

[gcolor3](https://gitlab.gnome.org/World/gcolor3) supports wayland nicely on ubuntu 22.04, if you build it from source.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
