### PR TITLE
Add missing displaylink support for Sway/wlroots

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -226,6 +226,11 @@
         Color management and HDR:
         <a href="https://gitlab.freedesktop.org/wayland/wayland-protocols/-/merge_requests/14">Protocol in development</a>
       </li>
+      <li class="list__item--ko">
+        Displaylink driver for:
+        <a href="https://github.com/swaywm/sway">Sway</a>/<a href="https://gitlab.freedesktop.org/wlroots/wlroots">wlroots:</a>
+        <a href="https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/1823">Issue on gitlab with a possible patch</a>
+      </li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Description

Displaylink driver makes possible for some monitor adapters to work, and it's widely used on office computers where you need to connect an HDMI to an USB for example, and it's multiplataform (Windows, Mac and Linux).

Unfortunately, it only works for Gnome Wayland, KDE Wayland and xserver in general, not Sway/wlroots

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [ x 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")