### PR TITLE
Added Anyrun to Application launchers

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,6 +10,7 @@
     <ul class="section__list">
       <li class="list__item--ok">
         Application launcher:
+        <a href="https://github.com/Kirottu/anyrun">Anyrun</a>,
         <a href="https://github.com/Cloudef/bemenu">bemenu</a>,
         <a href="https://codeberg.org/dnkl/fuzzel">Fuzzel</a>,
         <a href="https://code.rocketnine.space/tslocum/gmenu">gmenu</a>,


### PR DESCRIPTION
## Description

Added [Anyrun](https://github.com/Kirottu/anyrun) to the Application launchers section.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
