### PR TITLE
added pcmanfm to file managers

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -62,6 +62,7 @@
       <li class="list__item--ok">
         File manager:
         <a href="https://github.com/linuxmint/nemo">Nemo</a>
+	<a href="https://github.com/lxde/pcmanfm">pcmanfm</a>
       </li>
       <li class="list__item--ok">
         Gamma & day/night adjustment tool:


### PR DESCRIPTION
at least the gtk3 version works ok. Some issues with dragging, but nothing major.

## Description

Short description of the changes: I added pcmanfm, the lxde file manager, to file managers

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [ ] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [ ] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [ ] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
