### PR TITLE
Add Keypress screencasting section

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -235,6 +235,23 @@
         <a href="https://github.com/swaywm/sway">Sway</a>/<a href="https://gitlab.freedesktop.org/wlroots/wlroots">wlroots:</a>
         <a href="https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/1823">Issue on gitlab with a possible patch</a>
       </li>
+      <li class="list__item--ko">
+        Keypress screencasting:
+        <ul>
+          <li>
+            <a href="https://www.thregr.org/~wavexx/software/screenkey/">screenkey:</a>
+            <a href="https://gitlab.com/screenkey/screenkey/-/issues/61">Issue on GitLab</a>
+          </li>
+          <li>
+            <a href="https://github.com/ammgws/wshowkeys">wshowkeys:</a> 
+            Not maintained
+          </li>
+          <li>
+            <a href="https://vrsal.xyz/projects/input-overlay.html">OBS Studio Input Overlay</a>:
+            <a href="https://github.com/univrsal/input-overlay/issues/298">Issue on GitHub</a>
+          </li>
+        </ul>
+      </li>
     </ul>
   </section>
 


### PR DESCRIPTION
## Description

Short description of the changes:
Added a section to cover the screencasting of keys, i.e. show on screen the keypresses of any type, including modifier keys.

Opened as draft to first see if https://github.com/ammgws/wshowkeys actually works or not and if yes move it to the "Where is my" section (and also remove the others?)

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
