### PR TITLE
feat: add Ristretto and SDDM

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -80,6 +80,7 @@
         Image viewer:
         <a href="https://sr.ht/~exec64/imv/">imv</a>,
         <a href="https://nomacs.org/">nomacs</a>,
+        <a href="https://docs.xfce.org/apps/ristretto/start">Ristretto</a>,
         <a href="https://github.com/artemsen/swayimg">swayimg</a>
       </li>
       <li class="list__item--ok">
@@ -96,7 +97,8 @@
         Login manager:
         <a href="https://sr.ht/~kennylevinsen/greetd/">greetd</a>,
         <a href="https://github.com/max-moser/lightdm-elephant-greeter">LightDM Elephant Greeter</a>,
-        <a href="https://gitlab.com/marcusbritanicus/QtGreet">QtGreet</a>
+        <a href="https://gitlab.com/marcusbritanicus/QtGreet">QtGreet</a>,
+        <a href="https://github.com/sddm/sddm">SDDM</a>
       </li>
       <li class="list__item--ok">
         Network transparency:


### PR DESCRIPTION
## Description

Short description of the changes:

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
