### PR TITLE
Add wayclip

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,6 +27,7 @@
         Clipboard manager:
         <a href="https://github.com/sentriz/cliphist">cliphist</a>,
         <a href="https://github.com/yory8/clipman">Clipman</a>,
+        <a href="https://sr.ht/~noocsharp/wayclip/">wayclip</a>,
         <a href="https://github.com/bugaevc/wl-clipboard">wl-clipboard</a>
       </li>
       <li class="list__item--ok">


### PR DESCRIPTION
Closes #163

## Description

Adds [wayclip](https://sr.ht/~noocsharp/wayclip/) clipboard manager

## Checklist

I have:

- [X] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [X] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [X] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [X] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [X] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [X] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
