### PR TITLE
add Satty - a screenshot tool inspired by Swappy and Flameshot

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -148,6 +148,7 @@
         Screenshot tool:
         <a href="https://flameshot.org/">Flameshot</a>,
         <a href="https://github.com/emersion/grim">grim</a>/<a href="https://github.com/emersion/slurp">slurp</a>,
+        <a href="https://github.com/gabm/satty">Satty</a>,
         <a href="https://git.sr.ht/~whynothugo/shotman">Shotman</a>,
         <a href="https://github.com/jtheoof/swappy">swappy</a>
       </li>


### PR DESCRIPTION
## Description

Added Satty, a screenshot tool inspired by Swappy and Flameshot.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [ ] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
