### PR TITLE
Update yambar repository link to Codeberg

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -162,7 +162,7 @@
         <a href="https://github.com/hcsubser/hybridbar">Hybridbar</a>,
         <a href="https://github.com/nwg-piotr/nwg-panel">nwg-panel</a>,
         <a href="https://github.com/Alexays/Waybar">Waybar</a>,
-        <a href="https://gitlab.com/dnkl/yambar">Yambar</a>
+        <a href="https://codeberg.org/dnkl/yambar">Yambar</a>
       </li>
       <li class="list__item--ok">
         System monitoring widget:


### PR DESCRIPTION
## Description
Short description of the changes:
Replaces yambar gitlab repo with codeberg as the gitlab mirror is no longer updated.

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
