### PR TITLE
feat: Add xdg-desktop-portal-hyprland to "Screen Sharing"

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -143,6 +143,7 @@
       <li class="list__item--ok">
         Screen sharing:
         <a href="https://github.com/emersion/xdg-desktop-portal-wlr">xdg-desktop-portal-wlr</a>
+	<a href="https://github.com/hyprwm/xdg-desktop-portal-hyprland">xdg-desktop-portal-hyprland</a>
       </li>
       <li class="list__item--ok">
         Screenshot tool:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -142,8 +142,8 @@
       </li>
       <li class="list__item--ok">
         Screen sharing:
+        <a href="https://github.com/hyprwm/xdg-desktop-portal-hyprland">xdg-desktop-portal-hyprland</a>
         <a href="https://github.com/emersion/xdg-desktop-portal-wlr">xdg-desktop-portal-wlr</a>
-	<a href="https://github.com/hyprwm/xdg-desktop-portal-hyprland">xdg-desktop-portal-hyprland</a>
       </li>
       <li class="list__item--ok">
         Screenshot tool:


### PR DESCRIPTION
## Description

Short description of the changes:

An [XDG Desktop Portal](https://github.com/flatpak/xdg-desktop-portal) backend for Hyprland forked from [xdg-desktop-portal-wlr](https://github.com/emersion/xdg-desktop-portal-wlr).

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
