### PR TITLE
feat: Add Makima to list of keyboard remapping tools

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -90,8 +90,8 @@
         <a href="https://github.com/samvel1024/kbct">kbct</a>,
         <a href="https://github.com/rvaiya/keyd">keyd</a>,
         <a href="https://github.com/kmonad/kmonad">KMonad</a>,
-        <a href="https://github.com/k0kubun/xremap">xremap</a>,
-        <a href="https://github.com/cyber-sushi/makima">Makima</a>
+        <a href="https://github.com/cyber-sushi/makima">Makima</a>,
+        <a href="https://github.com/k0kubun/xremap">xremap</a>
       </li>
       <li class="list__item--ok">
         Login manager:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -90,7 +90,8 @@
         <a href="https://github.com/samvel1024/kbct">kbct</a>,
         <a href="https://github.com/rvaiya/keyd">keyd</a>,
         <a href="https://github.com/kmonad/kmonad">KMonad</a>,
-        <a href="https://github.com/k0kubun/xremap">xremap</a>
+        <a href="https://github.com/k0kubun/xremap">xremap</a>,
+        <a href="https://github.com/cyber-sushi/makima">makima</a>
       </li>
       <li class="list__item--ok">
         Login manager:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -91,7 +91,7 @@
         <a href="https://github.com/rvaiya/keyd">keyd</a>,
         <a href="https://github.com/kmonad/kmonad">KMonad</a>,
         <a href="https://github.com/k0kubun/xremap">xremap</a>,
-        <a href="https://github.com/cyber-sushi/makima">makima</a>
+        <a href="https://github.com/cyber-sushi/makima">Makima</a>
       </li>
       <li class="list__item--ok">
         Login manager:


### PR DESCRIPTION
## Description

Short description of the changes:
Adds Makima to the list of keyboard remapping tools.

## Checklist

I have:

- [v] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [v] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [v] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [v] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [v] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [v] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
