### PR TITLE
Add shikane to list of display configuration tools

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -113,6 +113,7 @@
         Output/display configuration tool:
         <a href="https://sr.ht/~emersion/kanshi">kanshi</a>,
         <a href="https://github.com/nwg-piotr/nwg-displays">nwg-displays</a>,
+        <a href="https://gitlab.com/w0lff/shikane">shikane</a>,
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/artizirk/wdisplays">wdisplays</a>,
         <a href="https://sr.ht/~leon_plickat/wlopm">wlopm</a>,


### PR DESCRIPTION
## Description

Add shikane to list of display configuration tools

## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
