### PR TITLE
Alt tab swtchr

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -9,6 +9,10 @@
     <p class="section__title">OK, but where is my:</p>
     <ul class="section__list">
       <li class="list__item--ok">
+        Alt-Tab functionality:
+        <a href="https://github.com/lostatc/swtchr">swtchr</a>
+      </li>
+      <li class="list__item--ok">
         Application launcher:
         <a href="https://github.com/Kirottu/anyrun">Anyrun</a>,
         <a href="https://github.com/Cloudef/bemenu">bemenu</a>,
@@ -189,10 +193,6 @@
         <a href="https://github.com/swaywm/sway">Sway</a>,
         <a href="https://github.com/michaelforney/velox">velox</a>,
         <a href="https://github.com/inclement/vivarium">vivarium</a>
-      </li>
-      <li class="list__item--ok"
-        Alt-Tab functionality:
-        <a href="https://github.com/lostatc/swtchr">swtchr</a>
       </li>
       <li class="list__item--ok">
         User input simulating tool:

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -190,6 +190,10 @@
         <a href="https://github.com/michaelforney/velox">velox</a>,
         <a href="https://github.com/inclement/vivarium">vivarium</a>
       </li>
+      <li class="list__item--ok"
+        Alt-Tab functionality:
+        <a href="https://github.com/lostatc/swtchr">swtchr</a>
+      </li>
       <li class="list__item--ok">
         User input simulating tool:
         <a href="https://gitlab.freedesktop.org/libinput/libei">libei</a>,


### PR DESCRIPTION
## Description

For a long time I was looking for a proper Alt-Tab functionality. This PR adds a section for it and a nice implementation I was referred to by @werdahias.

## Checklist

I have:

- [+] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [+] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [+] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [+] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [+] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [+] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")
