### PR TITLE
Update wlr-randr link to GitLab

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -116,7 +116,7 @@
         <a href="https://github.com/xyproto/wallutils">Wallutils</a>,
         <a href="https://github.com/artizirk/wdisplays">wdisplays</a>,
         <a href="https://sr.ht/~leon_plickat/wlopm">wlopm</a>,
-        <a href="https://sr.ht/~emersion/wlr-randr">wlr-randr</a>
+        <a href="https://gitlab.freedesktop.org/emersion/wlr-randr">wlr-randr</a>
       </li>
       <li class="list__item--ok">
         Power menu:


### PR DESCRIPTION
Update wlr-randr link to point to GitLab, as project moved to gitlab

Disclaimer on sourcehut:

> Warning: this project has moved to gitlab.freedesktop.org.


## Checklist

I have:

- [x] 🤳 made sure that what I am adding is an app for end users, not a developer tool / library (no "wl-clipboard-rs")
- [x] 🔗 checked that the link I am using refers to the root of the project (example, https://mpv.io) or GitHub repo **if the first is not available**
- [x] 🤓 checked BOTH the name and the casing of the project(s) I am adding ("GNOME Terminal" and not "gnome-terminal", "bemenu" and not "Bemenu", etc.)
- [x] 💣 checked that I am using spaces for indentation and that my levels are correct (**no tabs!**)
- [x] ✋ checked that my section has the correct casing ("My section", and not "My Section")
- [x] 📝 checked that the projects and / or the section are alphabetically sorted ("Clipboard manager" then "Color picker", "bemenu" then "Fuzzel")


